### PR TITLE
Feature/sendmail

### DIFF
--- a/R/conf.R
+++ b/R/conf.R
@@ -138,7 +138,7 @@ checkConfElements = function(cluster.functions, mail.to, mail.from,
   if (!missing(mail.error))
     assertChoice(mail.error, mail.choices)
   if (!missing(mail.control))
-    assertList(mail.control)
+    assert( is.function(mail.control) || is.list(mail.control) )
   if (!missing(db.driver))
     assertString(db.driver)
   if (!missing(db.options))

--- a/R/sendMail.R
+++ b/R/sendMail.R
@@ -34,6 +34,11 @@ sendMail = function(reg, ids, result.str, extra.msg = "",
     }
 
     # if a mail problem occurs, we only warn but do not terminate
+    if( is.function(conf$mail.control) ){ # use email function if nessecary
+      sendmail <- function(from, to, subj, msg, ...){
+        conf$mail.control(from, to, subj, msg)
+      }
+    }
     ok = try (sendmail(conf$mail.from, conf$mail.to, subj, msg, control = conf$mail.control))
     if (is.error(ok)) {
       warningf("Could not send mail to signal condition '%s'!\nFrom: %s\nTo: %s\nControl: %s\nError message: %s",

--- a/R/sendMail.R
+++ b/R/sendMail.R
@@ -36,7 +36,7 @@ sendMail = function(reg, ids, result.str, extra.msg = "",
     # if a mail problem occurs, we only warn but do not terminate
     if( is.function(conf$mail.control) ){ # use email function if nessecary
       sendmail <- function(from, to, subj, msg, ...){
-        conf$mail.control(from, to, subj, msg)
+        conf$mail.control(status = condition, from = from, to = to, subject = subj, body = msg)
       }
     }
     ok = try (sendmail(conf$mail.from, conf$mail.to, subj, msg, control = conf$mail.control))


### PR DESCRIPTION
Hi,

this PR is to enable users to define and use their own ``sendmail`` function as a hook.
I had to use this because of some restrictions on our clusters. I have a workaround in place that I can use to sen emails, but I needed this simple hook to trigger it, instead of the default SMTP-based function from ``sendmailR``.

It has no impact on the rest of the package. The custom mailing function only needs to have arguments ``status, from, to, subject, body``.
