### PR TITLE
allow passing arguments down to source() from loadConfig()

### DIFF
--- a/R/conf.R
+++ b/R/conf.R
@@ -11,11 +11,11 @@
 NULL
 
 # sources 1 config file and returns the envir
-sourceConfFile = function(conffile) {
+sourceConfFile = function(conffile, ...) {
   assertFile(conffile)
 
   conf = new.env()
-  x = try(sys.source(conffile, envir = conf))
+  x = try(sys.source(conffile, envir = conf, ...))
   if (is.error(x))
     stopf("There was an error in sourcing your configuration file '%s': %s!", conffile, as.character(x))
   checkConf(conf)
@@ -205,12 +205,14 @@ print.Config = function(x, ...) {
 #' @param conffile [\code{character(1)}]\cr
 #'   Location of the configuration file to load.
 #'   Default is \dQuote{.BatchJobs.conf} in the current working directory.
+#' @param ... 
+#'   Further arguments to \code{sys.source} (currently just \code{chdir})
 #' @return Invisibly returns a list of configuration settings.
 #' @family conf
 #' @export
-loadConfig = function(conffile = ".BatchJobs.R") {
+loadConfig = function(conffile = ".BatchJobs.R", ...) {
   # checks are done in sourceConfFile
-  conf = sourceConfFile(conffile)
+  conf = sourceConfFile(conffile, ...)
   assignConf(conf)
   invisible(setClasses(as.list(conf), "Config"))
 }

--- a/man/loadConfig.Rd
+++ b/man/loadConfig.Rd
@@ -4,12 +4,14 @@
 \alias{loadConfig}
 \title{Load a specific configuration file.}
 \usage{
-loadConfig(conffile = ".BatchJobs.R")
+loadConfig(conffile = ".BatchJobs.R", ...)
 }
 \arguments{
 \item{conffile}{[\code{character(1)}]\cr
 Location of the configuration file to load.
 Default is \dQuote{.BatchJobs.conf} in the current working directory.}
+
+\item{...}{Further arguments to \code{sys.source} (currently just \code{chdir})}
 }
 \value{
 Invisibly returns a list of configuration settings.


### PR DESCRIPTION
When using BatchJobs in moderately sized codebases, it can be helpful to use relative paths for both .tmpl and config files. `loadConfig()` uses `sys.source()` (via `sourceConfFile()`), which by default sources the config file relative to the current path, not the path of the config file itself. There are a number of ways to address this -- I think I picked the least disruptive (but maybe most awkward), which is passing arguments from `loadConfig()` down to `sys.source()`, and passing `chdir=T` to evaluate paths in the config file relative to its own directory. 