### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # BatchJobs
 
-[![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/BatchJobs)](http://cran.r-project.org/web/packages/BatchJobs)
-[![CRAN Downloads](http://cranlogs.r-pkg.org/badges/BatchJobs)](http://cran.rstudio.com/web/packages/BatchJobs/index.html)
+[![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/BatchJobs)](http://cran.r-project.org/web/packages/BatchJobs/)
+[![CRAN Downloads](http://cranlogs.r-pkg.org/badges/BatchJobs)](https://cran.rstudio.com/web/packages/BatchJobs/index.html)
 [![Build Status](https://travis-ci.org/tudo-r/BatchJobs.svg)](https://travis-ci.org/tudo-r/BatchJobs)
 [![Build status](https://ci.appveyor.com/api/projects/status/pkcy60csbp8k1ms9/branch/master?svg=true)](https://ci.appveyor.com/project/mllg/batchjobs/branch/master)
 [![Coverage Status](https://coveralls.io/repos/tudo-r/BatchJobs/badge.svg)](https://coveralls.io/r/tudo-r/BatchJobs)
@@ -19,7 +19,7 @@ Provides Map, Reduce and Filter variants to generate jobs on batch computing sys
   devtools::install_github("tudo-r/BatchJobs")
   ```
 
-* [Further installation instructions](https://github.com/tudo-r/PackagesInfo/wiki/Installation-Information)
+* [Further installation instructions](https://github.com/rdatsci/PackagesInfo/wiki/Installation-Information)
 
 ## If you use the package, please cite it and star it here
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
 * Support for makeshift SSH clusters and local (multicore) execution
 * Convenient collection and aggregation of results
 * Further Map and Reduce results from previous jobs as batch jobs
-* Optional mail sending using [sendmailR](http://cran.r-project.org/web/packages/sendmailR) after job completion
+* Optional mail sending using [sendmailR](http://cran.r-project.org/web/packages/sendmailR/) after job completion
 * Query status of jobs and display log files inside R
 * Possibility to write your own simple cluster interface if your architecture is not supported
 * [BatchExperiments](https://github.com/tudo-r/Batchexperiments) extends this package with functionality required for comprehensive computer experiments and simulation studies.


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/tudo-r/PackagesInfo/wiki/Installation-Information | https://github.com/rdatsci/PackagesInfo/wiki/Installation-Information 


### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://cran.rstudio.com/web/packages/BatchJobs/index.html | https://cran.rstudio.com/web/packages/BatchJobs/index.html 


### Other Corrected URLs 
Was | Now 
--- | --- 
http://cran.r-project.org/web/packages/BatchJobs | http://cran.r-project.org/web/packages/BatchJobs/ 
http://cran.r-project.org/web/packages/sendmailR | http://cran.r-project.org/web/packages/sendmailR/ 
