### PR TITLE
Additional parameters for SLURM to work correctly on LRZ cluster

### DIFF
--- a/R/clusterFunctionsSLURM.R
+++ b/R/clusterFunctionsSLURM.R
@@ -69,10 +69,9 @@ makeClusterFunctionsSLURM = function(template.file, list.jobs.cmd = c("squeue", 
   listJobs = function(conf, reg) {
     # Result is lines of fully quantified batch.job.ids
     jids = runOSCommandLinux(list.jobs.cmd[1L], list.jobs.cmd[-1L])$output
-    if (list.job.line.skip > 0) {
-      jids <- jids[-seq_len(list.job.line.skip)]
+    if (list.job.line.skip > 0L) {
+      jids = jids[-seq_len(list.job.line.skip)]
     }
-    jids 
     stri_extract_first_regex(jids, "[0-9]+")
   }
 

--- a/R/clusterFunctionsSLURM.R
+++ b/R/clusterFunctionsSLURM.R
@@ -28,9 +28,9 @@
 #' @family clusterFunctions
 #' @export
 makeClusterFunctionsSLURM = function(template.file, list.jobs.cmd = c("squeue", "-h", "-o %i", "-u $USER"),
-                                     list.job.line.skip = 0L, cluster.name) {
+                                     list.job.line.skip = 0L, cluster.name = NULL) {
   
-  if (!missing(cluster.name)) {
+  if (!is.null(cluster.name)) {
     assertString(cluster.name)
     list.jobs.cmd = append(list.jobs.cmd, paste0("--clusters=", cluster.name))
   }
@@ -58,17 +58,19 @@ makeClusterFunctionsSLURM = function(template.file, list.jobs.cmd = c("squeue", 
   }
 
   killJob = function(conf, reg, batch.job.id) {
+
     
-    killCmd = "scancel"
-    if (!missing(cluster.name)) {
-      killCmd = paste0(killCmd, " --clusters=", cluster.name)
+    if (!is.null(cluster.name)) {
+      cfKillBatchJob("scancel",paste0("--clusters=", cluster.name, " ", batch.job.id))
     }
-    cfKillBatchJob(killCmd, batch.job.id)
+    cfKillBatchJob("scancel", batch.job.id)
   }
 
   listJobs = function(conf, reg) {
     # Result is lines of fully quantified batch.job.ids
     jids = runOSCommandLinux(list.jobs.cmd[1L], list.jobs.cmd[-1L])$output
+    # if squeue returns additional information (like cluster name), one or more
+    # lines can be omitted
     if (list.job.line.skip > 0L) {
       jids = jids[-seq_len(list.job.line.skip)]
     }

--- a/man/makeClusterFunctionsSLURM.Rd
+++ b/man/makeClusterFunctionsSLURM.Rd
@@ -5,7 +5,7 @@
 \title{Create cluster functions for SLURM-based systems.}
 \usage{
 makeClusterFunctionsSLURM(template.file, list.jobs.cmd = c("squeue", "-h",
-  "-o \%i", "-u $USER"))
+  "-o \%i", "-u $USER"), list.job.line.skip = 0L, cluster.name)
 }
 \arguments{
 \item{template.file}{[\code{character(1)}]\cr
@@ -15,6 +15,14 @@ Path to a brew template file that is used for the PBS job file.}
 Change default system command / options to list jobs.
 The first entry is the command, the following the options.
 See \code{\link[BBmisc]{system3}}.}
+
+\item{list.job.line.skip}{[\code{integer(1)}]\cr
+Change how many lines of the job list should be skipped. Can be useful if \code{squeue} is giving
+additional output.}
+
+\item{cluster.name}{[\code{character(1)}]\cr
+If an additional cluster name has to be specified for listing or deleting jobs it can be 
+supplied with this argument. it will be added as \code{--clusters=cluster.name} for SLURM.}
 }
 \value{
 [\code{\link{ClusterFunctions}}].


### PR DESCRIPTION
For BatchJobs to work on the LRZ cluster some additional parameters have to be specified for listing and killing jobs correctly.


We have to supply the the cluster name and be able to remove the first element of the JobList because it just states the clusters name and we cannot remove it with a `list.jobs.cmd` command.

EDIT: Well we could do somethings like  `| tail -n +2` in `list.jobs.cmd` but thats not really a nice solution.